### PR TITLE
log response body after a request

### DIFF
--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -29,7 +29,7 @@ module OpenSRS
 
       begin
         response = http.post(server_path, xml, headers(xml))
-        log('Response', xml, data)
+        log('Response', response.body, data)
       rescue Net::HTTPBadResponse
         raise OpenSRS::BadResponse, "Received a bad response from OpenSRS. Please check that your IP address is added to the whitelist, and try again."
       end

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -117,7 +117,9 @@ describe OpenSRS::Server do
         server.call(:some => 'option')
         logger.messages.length.should eq(2)
         logger.messages.first.should match(/\[OpenSRS\] Request XML/)
+        logger.messages.first.should match(/<some xml>/)
         logger.messages.last.should match(/\[OpenSRS\] Response XML/)
+        logger.messages.last.should match(/some response/)
       end
 
     end


### PR DESCRIPTION
@jstorimer 

The logger is writing the request XML instead of the response XML after a request is made.

I know we've moved to the upstream gem in Shopify; after review I'll make a PR against upstream with this commit.
