### PR TITLE
Update libxml for Ruby 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "nokogiri", "~> 1.6.1"
 
 group :development do
-  gem "libxml-ruby", "~> 2.6.0"
+  gem "libxml-ruby", "~> 2.7.0"
   gem "jeweler"
   gem "git"
   gem "rake"

--- a/opensrs.gemspec
+++ b/opensrs.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.6.0"])
+      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.7.0"])
       s.add_development_dependency(%q<nokogiri>, ["~> 1.6.1"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<git>, [">= 0"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.0"])
     else
-      s.add_dependency(%q<libxml-ruby>, ["~> 2.6.0"])
+      s.add_dependency(%q<libxml-ruby>, ["~> 2.7.0"])
       s.add_dependency(%q<nokogiri>, ["~> 1.6.1"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<git>, [">= 0"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rspec>, ["~> 2.0"])
     end
   else
-    s.add_dependency(%q<libxml-ruby>, ["~> 2.6.0"])
+    s.add_dependency(%q<libxml-ruby>, ["~> 2.7.0"])
     s.add_dependency(%q<nokogiri>, ["~> 1.6.1"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<git>, [">= 0"])


### PR DESCRIPTION
@jstorimer, @peterjm, @fw42 

libxml-ruby 2.6.0 is not compatible with Ruby 2.2 - `bundle install` fails when trying to build the gem.

This updates the libxml-ruby gem to 2.7.0, which is compatible. This is backwards compatible with Ruby 2.1.x. I have a [CI run](https://circleci.com/gh/Shopify/shopify/166851) that is green with this rev of the opensrs gem.