### PR TITLE
experimental: remove libxml-ruby dep entirely

### DIFF
--- a/opensrs.gemspec
+++ b/opensrs.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.7.0"])
       s.add_development_dependency(%q<nokogiri>, ["~> 1.6.1"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<git>, [">= 0"])
@@ -55,7 +54,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.0"])
     else
-      s.add_dependency(%q<libxml-ruby>, ["~> 2.7.0"])
       s.add_dependency(%q<nokogiri>, ["~> 1.6.1"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<git>, [">= 0"])
@@ -64,7 +62,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rspec>, ["~> 2.0"])
     end
   else
-    s.add_dependency(%q<libxml-ruby>, ["~> 2.7.0"])
     s.add_dependency(%q<nokogiri>, ["~> 1.6.1"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<git>, [">= 0"])


### PR DESCRIPTION
We're seeing segfaults on Spaces CI after adding this gem. Removing it from deps makes it go away.

@danschultzer this should be merged before we offer domain registrations to our users, just to make sure we don't miss future stuff that gets fixed in master
cc @cjoudrey 