### PR TITLE
Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ To connect, instantiate a new <tt>OpenSRS::Server</tt> object:
 
 **NOTE:** Connecting to OpenSRS requires that you add the IP(s) you're connecting from to their whitelist. Log in to the testing or production servers, and add your IP(s) under Profile Management > Add IPs for Script/API Access. IP changes take about one hour to take effect.
 
+Since OpenSRS only allows up to 5 IPs to be whitelisted, you may wish to use a proxy. `OpenSRS::Server` uses `Net::HTTP`, so you can configure an unauthenticated proxy with the `http_proxy` environment variable. If the proxy requires authentication, you must supply it explicitly:
+
+    server = OpenSRS::Server.new(
+      server:   "https://rr-n1-tor.opensrs.net:55443/",
+      username: "testing",
+      password: "53cr3t",
+      key:      "c633be3170c7fb3fb29e2f99b84be2410...",
+      proxy:    "http://user:password@example.com:8080",
+    )
+
 If you would like, you can provide OpenSRS::Server with a logger to write the contents of the requests and responses
 with OpenSRS. The assumption is you are using a Rails-like logger, but as long as your logger has an info method you
 are fine. You can simply assign the logger or pass it in as an initialization option:

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -18,7 +18,8 @@ module OpenSRS
                   :timeout,
                   :open_timeout,
                   :logger,
-                  :sanitize_logs
+                  :sanitize_logs,
+                  :proxy
 
     SANITIZING_METHODS = [
       :sanitize_rw_register
@@ -33,6 +34,7 @@ module OpenSRS
       @open_timeout = options[:open_timeout]
       @logger   = options[:logger]
       @sanitize_logs = options[:sanitize_logs]
+      @proxy    = URI.parse(options[:proxy]) if options[:proxy]
     end
 
     def call(data = {})
@@ -79,7 +81,12 @@ module OpenSRS
     end
 
     def http
-      http = Net::HTTP.new(server.host, server.port)
+      if @proxy
+        http = Net::HTTP.new server.host, server.port,
+          @proxy.host, @proxy.port, @proxy.user, @proxy.password
+      else
+        http = Net::HTTP.new(server.host, server.port)
+      end
       http.use_ssl = (server.scheme == "https")
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       http.read_timeout = http.open_timeout = @timeout if @timeout

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -81,11 +81,11 @@ module OpenSRS
     end
 
     def http
-      if @proxy
-        http = Net::HTTP.new server.host, server.port,
+      http = if @proxy
+        Net::HTTP.new server.host, server.port,
           @proxy.host, @proxy.port, @proxy.user, @proxy.password
       else
-        http = Net::HTTP.new(server.host, server.port)
+        Net::HTTP.new(server.host, server.port)
       end
       http.use_ssl = (server.scheme == "https")
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -31,6 +31,13 @@ describe OpenSRS::Server do
 
       expect(server.logger).to be(logger)
     end
+
+    it 'allows a proxy to be set during initialization' do
+      proxy = 'http://user:password@example.com:1234'
+      server = OpenSRS::Server.new(proxy: proxy)
+
+      expect(server.proxy).to be_a(URI)
+    end
   end
 
   describe ".call" do
@@ -96,6 +103,20 @@ describe OpenSRS::Server do
       http.should_receive(:open_timeout=).with(30)
 
       server.call( { :some => 'data' } )
+    end
+
+    it 'allows setting a proxy' do
+      proxy = URI('http://user:password@example.com:1234')
+      server.proxy = proxy
+
+      Net::HTTP.should_receive(:new).with anything,
+        anything,
+        proxy.host,
+        proxy.port,
+        proxy.user,
+        proxy.password
+
+      server.call(some: 'data')
     end
 
     it 're-raises Net:HTTP timeouts' do


### PR DESCRIPTION
Since OpenSRS requires you to whitelist IP addresses, it would be useful to set a proxy for OpenSRS requests. Net::HTTP will automatically use the ENV["http_proxy"] variable but this doesn't work when the proxy requires authentication. Largely plagiarized from https://github.com/voxxit/opensrs/pull/36