### PR TITLE
Add log compaction and up ruby version

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,7 +5,7 @@ type: ruby
 up:
   - homebrew:
     - openssl
-  - ruby: 2.3.0
+  - ruby: 2.5.3
   - bundler
 
 commands:

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -18,6 +18,7 @@ module OpenSRS
                   :timeout,
                   :open_timeout,
                   :logger,
+                  :log_compaction,
                   :sanitize_logs,
                   :proxy
 
@@ -33,6 +34,7 @@ module OpenSRS
       @timeout  = options[:timeout]
       @open_timeout = options[:open_timeout]
       @logger   = options[:logger]
+      @log_compaction   = options[:log_compaction]
       @sanitize_logs = options[:sanitize_logs]
       @proxy    = URI.parse(options[:proxy]) if options[:proxy]
     end
@@ -117,6 +119,7 @@ module OpenSRS
       message = "#{message} for #{options[:object]} #{options[:action]}" if options[:object] && options[:action]
 
       line = [message, sanitize(type, data, options)].join("\n")
+      line.delete!("\n") if log_compaction
       logger.info(line)
     end
 

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -150,7 +150,7 @@ describe OpenSRS::Server do
       end
 
       describe "sanitize_logs" do
-        let(:xml) { '<item>foo</item><item key="reg_password">password</item>' }
+        let(:xml) { "<?xml version=\"1.0\"?>\n<OPS_envelope>\n<item>foo</item><item key=\"reg_password\">password</item>\n/OPS_envelope>\n" }
         before :each do
           xml_processor.stub(:build).and_return xml
           xml_processor.stub(:parse).and_return xml
@@ -174,6 +174,21 @@ describe OpenSRS::Server do
           expect(logger.messages.first).to match(
             %r{<item key="reg_password">password<\/item>}
           )
+        end
+
+        it 'if log_compaction is on, remove lines from logs' do
+          server.log_compaction = true
+
+          server.call(action: "SW_REGISTER", object: "DOMAIN")
+
+          expect(logger.messages.first).not_to include("\n")
+        end
+
+        it 'if log_compaction is off, do not remove lines from logs' do
+          server.log_compaction = false
+
+          server.call(action: "SW_REGISTER", object: "DOMAIN")
+          expect(logger.messages.first).to include("\n")
         end
       end
     end


### PR DESCRIPTION
Add log_compaction parameter to Server initialization to allow XML logs to have new lines stripped for space-saving.

Also, bump the ruby version.