### PR TITLE
Remove empty spaces when compacting logs

### DIFF
--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -118,9 +118,10 @@ module OpenSRS
       message = "[OpenSRS] #{type} XML"
       message = "#{message} for #{options[:object]} #{options[:action]}" if options[:object] && options[:action]
 
-      line = [message, sanitize(type, data, options)].join("\n")
-      line.delete!("\n") if log_compaction
-      logger.info(line)
+      logs = [message, sanitize(type, data, options)].join("\n")
+      logs = logs.split("\n").each { |line| line.lstrip! }.join('') if log_compaction
+
+      logger.info(logs)
     end
 
     def server_path

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -150,7 +150,7 @@ describe OpenSRS::Server do
       end
 
       describe "sanitize_logs" do
-        let(:xml) { "<?xml version=\"1.0\"?>\n<OPS_envelope>\n<item>foo</item><item key=\"reg_password\">password</item>\n/OPS_envelope>\n" }
+        let(:xml) { "<?xml version=\"1.0\"?>\n   <OPS_envelope>\n<item>foo bar</item><item key=\"reg_password\">password</item>\n/OPS_envelope>\n" }
         before :each do
           xml_processor.stub(:build).and_return xml
           xml_processor.stub(:parse).and_return xml
@@ -176,12 +176,12 @@ describe OpenSRS::Server do
           )
         end
 
-        it 'if log_compaction is on, remove lines from logs' do
+        it 'if log_compaction is on, remove lines and whitespace from the left from logs' do
           server.log_compaction = true
 
           server.call(action: "SW_REGISTER", object: "DOMAIN")
 
-          expect(logger.messages.first).not_to include("\n")
+          expect(logger.messages.first).to eq("[OpenSRS] Request XML for DOMAIN SW_REGISTER<?xml version=\"1.0\"?><OPS_envelope><item>foo bar</item><item key=\"reg_password\">password</item>/OPS_envelope>")
         end
 
         it 'if log_compaction is off, do not remove lines from logs' do


### PR DESCRIPTION
Log compaction still had empty spaces at the start of lines:
```
<?xml version="1.0"?><OPS_envelope>  <header>    <version>0.9</version>  </h
eader>  <body>    <data_block>      <dt_assoc>        <item key="protocol">XCP</item>        <item key="action">SET_DNS_ZONE</item>        <item key="object">DOMAIN</item>        <item key="a
ttributes">          <dt_assoc>            <item key="domain">safseds.com</item>            <item key="records">              <dt_assoc>                <item key="A">                  <dt_arr
ay>                    <item key="0">                      <dt_assoc>                        <item key="type">A</item>                        <item key="ip_address">23.227.38.32</item>
                 <item key="subdomain"/>                      </dt_assoc>                    </item>                  </dt_array>                </item>                <item key="AAAA">
            <dt_array>                    <item key="0">                      <dt_assoc>                        <item key="type">AAAA</item>                        <item key="ipv6_address">::
1</item>                        <item key="subdomain"/>                      </dt_assoc>                    </item>                  </dt_array>                </item>                <item ke
y="SRV">                  <dt_array>                    <item key="0">                      <dt_assoc>                        <item key="type">SRV</item>                        <item key="hos
tname">asd.asd.com</item>                        <item key="subdomain">asd.asd</item>                        <item key="priority">1</item>                        <item key="weight">1</item>
                      <item key="port">1</item>                      </dt_assoc>                    </item>                  </dt_array>                </item>                <item key="CNAME
">                  <dt_array>                    <item key="0">                      <dt_assoc>                        <item key="type">CNAME</item>                        <item key="hostnam
e">shops.myshopify.com</item>                        <item key="subdomain">www</item>                      </dt_assoc>                    </item>                  </dt_array>                <
/item>                <item key="TXT">                  <dt_array>                    <item key="0">                      <dt_assoc>                        <item key="type">TXT</item>
                <item key="subdomain">_provider</item>                        <item key="text">shopify</item>                      </dt_assoc>                    </item>                  </dt
_array>                </item>              </dt_assoc>            </item>          </dt_assoc>        </item>      </dt_assoc>    </data_block>  </body></OPS_envelope>
```

This will remove those.