### PR TITLE
Allow to customize the SSL ciphers

### DIFF
--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -11,6 +11,11 @@ module OpenSRS
   class TimeoutError < ConnectionError; end
 
   class Server
+    class << self
+      attr_accessor :ciphers
+    end
+    self.ciphers = 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
+
     attr_accessor :server,
                   :username,
                   :password,
@@ -90,7 +95,9 @@ module OpenSRS
         Net::HTTP.new(server.host, server.port)
       end
       http.use_ssl = (server.scheme == "https")
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if self.class.ciphers
+        http.ciphers = self.class.ciphers
+      end
       http.read_timeout = http.open_timeout = @timeout if @timeout
       http.open_timeout = @open_timeout                if @open_timeout
       http


### PR DESCRIPTION
### Context

After upgrading to ubuntu 20.04, we started seeing this error:

```
There was a problem connecting to https://rr-n1-tor.opensrs.net:55443 - SSL_connect returned=1 errno=0 state=error: dh key too small (SSLErrors::SSLError)
```

This is because OpenSRS is using SSL ciphers that have been removed in newer OpenSSL release because they were insecure (https://weakdh.org/).

### Solution

As a workaround, we can actually select the ciphers we want to use in the net/http client. Right now I use `AES128-SHA` because I [found it here](https://github.com/rapid7/metasploit-framework/issues/6783#issuecomment-289790372), but I don't have enough crypto knowledge to know wether it's the best to use.

It would also probably be a good idea to provide multiple ones, in case OpenSRS update their ciphers. I'll try to find a security dev to help me select a list of ciphers to use.

cc @jsaubry @miazbikowski 